### PR TITLE
Update x265 to 8c159ba54aaf7f3e815790e7951c2ed285d2e0a7 from 0b75c44c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=0b75c44c10e605fe9e9ebed58f04a46271131827
+ARG X265_VERSION=8c159ba54aaf7f3e815790e7951c2ed285d2e0a7
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
-ARG X265_SHA256=8aaf96bae0025c3678c3c04cf2e645af4ae0acb5520c890b80474e96b868f545
+ARG X265_SHA256=e7205f296a34af6179ef4d5a77c672e9fcfbb4bbd0d9fab0be96c92ffab9e336
 
 # Must be specified
 ARG ALPINE_VERSION


### PR DESCRIPTION
…10e605fe9e9ebed58f04a46271131827

Source diff 0b75c44c10e605fe9e9ebed58f04a46271131827..8c159ba54aaf7f3e815790e7951c2ed285d2e0a7 https://bitbucket.org/multicoreware/x265_git/branches/compare/8c159ba54aaf7f3e815790e7951c2ed285d2e0a7..0b75c44c10e605fe9e9ebed58f04a46271131827#diff